### PR TITLE
Remove hardcoded textAppearance for better theme support.

### DIFF
--- a/res/layout/preference_application_light.xml
+++ b/res/layout/preference_application_light.xml
@@ -74,15 +74,13 @@
             android:id="@+id/textViewTimeOnValue"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:textAppearance="@android:style/TextAppearance.Material.Notification.Line2" />
+            android:layout_gravity="end" />
 
         <TextView
             android:id="@+id/textViewTimeOffValue"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:textAppearance="@android:style/TextAppearance.Material.Notification.Line2" />
+            android:layout_gravity="end" />
     </LinearLayout>
 
     <ImageView


### PR DESCRIPTION
In Notification Light settings, the text was being set to style
from framework. This meant that the text was not respecting the
overall theme of the view. By removing the hardcoded style
references, the text will adopt colors based on the overall
theme.

Change-Id: Ia8b76548af20f66b386af3ea1122189de14b7385
Ticket: CYNGNOS-466